### PR TITLE
example use case where dot matches newline

### DIFF
--- a/01-chapter2.markdown
+++ b/01-chapter2.markdown
@@ -247,6 +247,27 @@ Now using the the (?s) flag, the newline is kept in the result.
 		// ar an as al ab am a
 		// ar ac]>
 	 	
+Clear out multi-line comments in css file
+
+		s := `/* multi line
+		comment with
+		url("http://commented1.test.com/img.jpg") */
+		body {
+		  background: #ffffff url("actual1.png") no-repeat right top;
+		}
+		/* single line commented out url("http://commented2.test.com/img.jpg") *//* back to back comment */
+		.test-img {
+		  background-image: url("http://test.com/actual2.png");
+		}`
+
+		re := regexp.MustCompile(`(?s)(?:/\*.*?\*/)?((?:[^/]|/[^*])*)`)
+		results := re.FindAllStringSubmatch(s, -1)
+		for _, v := range results {
+			if v[1] != "" {
+				fmt.Printf("%s", v[1])
+			}
+		}
+
 ## Shall ^/$ Match at a Newline? ##
 
 When we have a multiline string you can control

--- a/01-chapter2.markdown
+++ b/01-chapter2.markdown
@@ -267,6 +267,14 @@ Clear out multi-line comments in css file
 				fmt.Printf("%s", v[1])
 			}
 		}
+		// Prints
+		// body {
+		//   background: #ffffff url("actual1.png") no-repeat right top;
+		// }
+		//
+		// .test-img {
+		//   background-image: url("http://test.com/actual2.png");
+		// }
 
 ## Shall ^/$ Match at a Newline? ##
 


### PR DESCRIPTION
Saw a request for use case where dot matches newlines; so included this example to remove multi-line comments and tested on go playground. Normally a parser would be better in this case as broken CSS will not be detected and lead to bad results. One example would be a comment that never terminates. But for a quick cleanup of comments this regex may be helpful.